### PR TITLE
configure: Automatically detect the default xorg-module-dir.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,11 @@
 #  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 #  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+# During distcheck, system locations (as provided by pkg-config) may
+# not be writable; provide instead relative locations.
+DISTCHECK_CONFIGURE_FLAGS = --with-xorg-module-dir='$${libdir}/xorg/modules' \
+                            --enable-xspice
+
 SUBDIRS = src scripts examples
 
 MAINTAINERCLEANFILES = ChangeLog INSTALL
@@ -35,4 +40,3 @@ EXTRA_DIST = \
 	README.md		\
 	README.xspice
 
-DISTCHECK_CONFIGURE_FLAGS=--enable-xspice

--- a/configure.ac
+++ b/configure.ac
@@ -50,9 +50,12 @@ AC_PROG_LIBTOOL
 AH_TOP([#include "xorg-server.h"])
 
 # Define a configure option for an alternate module directory
-AC_ARG_WITH(xorg-module-dir, [  --with-xorg-module-dir=DIR ],
-                             [ moduledir="$withval" ],
-                             [ moduledir="$libdir/xorg/modules" ])
+PKG_PROG_PKG_CONFIG([0.25])
+AC_ARG_WITH(xorg-module-dir,
+            AS_HELP_STRING([--with-xorg-module-dir=DIR],
+                           [Default xorg module directory]),
+            [moduledir="$withval"],
+            [moduledir=`$PKG_CONFIG --variable=moduledir xorg-server`])
 AC_SUBST(moduledir)
 
 # Store the list of server defined optional extensions in REQUIRED_MODULES


### PR DESCRIPTION
The module directory has changed to a per ABI folder in the xlibre-xserver. Now the default value of `xorg-module-dir` will be detected from the `moduledir` variable in xorg-server.pc.