### PR TITLE
drop #ifdef RANDR_12_INTERFACE

### DIFF
--- a/src/qxl_drmmode.c
+++ b/src/qxl_drmmode.c
@@ -678,12 +678,9 @@ drmmode_output_get_property(xf86OutputPtr output, Atom property)
 static const xf86OutputFuncsRec drmmode_output_funcs = {
     .dpms = drmmode_output_dpms,
     .create_resources = drmmode_output_create_resources,
-#ifdef RANDR_12_INTERFACE
     .set_property = drmmode_output_set_property,
     .get_property = drmmode_output_get_property,
-#endif
 #if 0
-
     .save = drmmode_crt_save,
     .restore = drmmode_crt_restore,
     .mode_fixup = drmmode_crt_mode_fixup,

--- a/src/qxl_ums_mode.c
+++ b/src/qxl_ums_mode.c
@@ -278,10 +278,8 @@ qxl_output_mode_valid (xf86OutputPtr output, DisplayModePtr pModes)
 static const xf86OutputFuncsRec qxl_output_funcs = {
     .dpms = qxl_output_dpms,
     .create_resources = qxl_output_create_resources,
-#ifdef RANDR_12_INTERFACE
     .set_property = qxl_output_set_property,
     .get_property = qxl_output_get_property,
-#endif
     .detect = qxl_output_detect,
     .mode_valid = qxl_output_mode_valid,
 


### PR DESCRIPTION
All (non-ancient) Xservers have it.